### PR TITLE
Refactor CI workflow for Rust and npm publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: Swatinem/rust-cache@v2
 
     - name: Run tests
-      run: cargo test
+      run:  mkdir -p test-output/icons && cargo test
 
     - uses: jetli/wasm-pack-action@v0.4.0
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
 
     - uses: jetli/wasm-pack-action@v0.4.0
       with:
-        version: latest
+        version: v0.12.1
 
     - name: Build with wasm-pack
       run: wasm-pack build --release --target bundler

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,60 +16,36 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      
-    - name: Install Rust
-      uses: actions-rs/toolchain@v1
+    - uses: actions/checkout@v4
+
+    - uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: stable
-        override: true
         components: rustfmt, clippy
-        
-    - name: Cache cargo registry
-      uses: actions/cache@v3
-      with:
-        path: ~/.cargo/registry
-        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-        
-    - name: Cache cargo index
-      uses: actions/cache@v3
-      with:
-        path: ~/.cargo/git
-        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-        
-    - name: Cache cargo build
-      uses: actions/cache@v3
-      with:
-        path: target
-        key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+
+    - uses: Swatinem/rust-cache@v2
 
     - name: Run tests
-      run: mkdir -p test-output/icons && cargo test
-        
-    - name: Install wasm-pack
-      run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-      
+      run: cargo test
+
+    - uses: jetli/wasm-pack-action@v0.4.0
+      with:
+        version: latest
+
     - name: Build with wasm-pack
       run: wasm-pack build --release --target bundler
-      
-    - name: Setup Node.js (for npm authentication)
-      uses: actions/setup-node@v4
+
+    - uses: actions/setup-node@v4
       with:
         node-version: '22'
         registry-url: 'https://registry.npmjs.org'
         
     - name: Publish to npm
       if: github.event_name == 'release' && github.event.action == 'published'
-      run: wasm-pack publish
+      run: npm publish
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       
-        
-    - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v4
       with:
         name: wasm-package
-        path: |
-          pkg/
-          !pkg/node_modules/
+        path: pkg/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
-    
+
     steps:
     - uses: actions/checkout@v4
 
@@ -38,13 +38,13 @@ jobs:
       with:
         node-version: '22'
         registry-url: 'https://registry.npmjs.org'
-        
+
     - name: Publish to npm
       if: github.event_name == 'release' && github.event.action == 'published'
-      run: npm publish
+      run: wasm-pack publish
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      
+
     - uses: actions/upload-artifact@v4
       with:
         name: wasm-package


### PR DESCRIPTION
Updated the GitHub Actions workflow to use 'dtolnay/rust-toolchain' for Rust installation, added caching with 'Swatinem/rust-cache', and modified the publish step to use 'npm publish' instead of 'wasm-pack publish'.